### PR TITLE
敵の倒された時のエフェクトの表示条件を変更

### DIFF
--- a/Assets/Karaki/Script/HitObjectToDestroy.cs
+++ b/Assets/Karaki/Script/HitObjectToDestroy.cs
@@ -39,11 +39,16 @@ namespace Karaki
                 _hitCount -= Damage;
                 if (_hitCount < 1)
                 {
-                    GameObject effect = Instantiate(_PrefDefeatEffect);
-                    effect.transform.position = transform.position;
                     PhotonNetwork.Destroy(this.gameObject);
                 }
             }
+        }
+
+        void OnDestroy()
+        {
+            //倒された時のエフェクトは同期させる必要性がないため、個別に実行
+            GameObject effect = Instantiate(_PrefDefeatEffect);
+            effect.transform.position = transform.position;
         }
     }
 }


### PR DESCRIPTION
Destroyを行ったマスタークライアントでしかエフェクトが出ない形だったので、OnDestroyメソッド内でエフェクトを出させるように変更